### PR TITLE
Remove deno-ignore from routers

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -8,8 +8,9 @@ export {
   isHttpError,
   Router,
   send,
-  Status,
+  Status
 } from "https://deno.land/x/oak/mod.ts";
+export type { RouterMiddleware } from "https://deno.land/x/oak/mod.ts";
 export type { RouterContext, State } from "https://deno.land/x/oak/mod.ts";
 export { configSync } from "https://deno.land/std/dotenv/mod.ts";
 export { getLogger, handlers, setup } from "https://deno.land/std/log/mod.ts";

--- a/middlewares/auth.middleware.ts
+++ b/middlewares/auth.middleware.ts
@@ -1,5 +1,5 @@
 import { roleRights } from "../config/roles.ts";
-import { Status } from "../deps.ts";
+import { RouterMiddleware, Status } from "../deps.ts";
 import type { RouterContext } from "../deps.ts";
 import JwtHelper from "../helpers/jwt.helper.ts";
 import UserService from "../services/user.service.ts";
@@ -39,9 +39,9 @@ const checkRights = (
  * @param requiredRights
  * @returns Promise<void>
  */
-export const auth = (requiredRights: string[]) =>
+export const auth = <Path extends string>(requiredRights: string[]): RouterMiddleware<Path> =>
   async (
-    ctx: RouterContext<string>,
+    ctx: RouterContext<Path>,
     next: () => Promise<unknown>,
   ): Promise<void> => {
     let JWT: string;

--- a/middlewares/validate.middleware.ts
+++ b/middlewares/validate.middleware.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file
 
-import { helpers, RouterContext, Status } from "../deps.ts";
+import { helpers, RouterContext, RouterMiddleware, Status } from "../deps.ts";
 import { throwError } from "./errorHandler.middleware.ts";
 
 /**
@@ -57,8 +57,8 @@ const checkValidation = async (
  * @param schema
  * @returns Promise<void>
  */
-export const validate = (schema: any) =>
-  async (ctx: RouterContext<string>, next: () => any): Promise<void> => {
+export const validate = <Path extends string>(schema: any): RouterMiddleware<Path> =>
+  async (ctx: RouterContext<Path>, next: () => any): Promise<void> => {
     const { params: _params, queries: _query, body: _body } = schema;
     const allQueries = [
       {

--- a/routers/auth.router.ts
+++ b/routers/auth.router.ts
@@ -6,8 +6,7 @@ import {
   refreshTokenValidation,
 } from "../validations/auth.validation.ts";
 
-// deno-lint-ignore no-explicit-any
-const router: any = new Router();
+const router = new Router();
 
 router.post(
   "/api/auth/login",

--- a/routers/default.router.ts
+++ b/routers/default.router.ts
@@ -1,8 +1,7 @@
 import { Context, Router, send } from "../deps.ts";
 import configs from "../config/config.ts";
 
-// deno-lint-ignore no-explicit-any
-const router: any = new Router();
+const router = new Router();
 
 router.get("/(.*)", async (context: Context) => {
   if (configs.env === "production") {

--- a/routers/user.router.ts
+++ b/routers/user.router.ts
@@ -11,8 +11,7 @@ import {
   updateUserValidation,
 } from "../validations/user.validation.ts";
 
-// deno-lint-ignore no-explicit-any
-const router: any = new Router();
+const router = new Router();
 
 router.post(
   "/api/users",


### PR DESCRIPTION
By typing middlewares with oak's `RouterMiddleware` type we can remove the deno-ignore directives, I think its cleaner and better for new commers.

Sorry if theres something strange or not correct, its my first pull request :)